### PR TITLE
Make sure we use the original partners collection

### DIFF
--- a/src/Backend/Modules/Partners/Domain/Widget/Widget.php
+++ b/src/Backend/Modules/Partners/Domain/Widget/Widget.php
@@ -146,11 +146,12 @@ final class Widget
 
             $widget->title = $widgetDataTransferObject->title;
             $widget->template = $widgetDataTransferObject->template;
-            $widget->partners = $widgetDataTransferObject->partners->map(
-                function (PartnerDataTransferObject $partnerDataTransferObject) use ($widget) {
-                    return Partner::fromDataTransferObject($partnerDataTransferObject, $widget);
-                }
-            );
+            $widget->partners->clear();
+
+            /** @var PartnerDataTransferObject $partnerDataTransferObject */
+            foreach ($widgetDataTransferObject->partners as $partnerDataTransferObject) {
+                $widget->partners->add(Partner::fromDataTransferObject($partnerDataTransferObject, $widget));
+            }
 
             return $widget;
         }


### PR DESCRIPTION
Doctrine doesn't like new collections so we use the original collection, clear it and fill it up again.

Before, the original partners would disappear when editing a partner widget